### PR TITLE
Add Alt+arrow key navigation between vim and tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Adds [kdb syntax highlighting](https://github.com/patmok/qvim) from
 Adds [Vundle](https://github.com/VundleVim/Vundle.vim) a plugin manager for
 vim.
 
+Current plugins:
+- [tmux-vim-navigator](https://github.com/christoomey/vim-tmux-navigator) - allows
+ for alt+arrow key switching between vim and tmux.
+
 ### scripts
 
 Adds:

--- a/dotfiles/.tmux.conf
+++ b/dotfiles/.tmux.conf
@@ -17,3 +17,18 @@ set-window-option -g mode-keys vi
 
 # to delay to escape key
 set -s escape-time 0
+
+# Smart pane switching with awareness of Vim splits.
+# See: https://github.com/christoomey/vim-tmux-navigator
+is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
+    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
+bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
+bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
+bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
+bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
+bind-key -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
+bind-key -T copy-mode-vi C-h select-pane -L
+bind-key -T copy-mode-vi C-j select-pane -D
+bind-key -T copy-mode-vi C-k select-pane -U
+bind-key -T copy-mode-vi C-l select-pane -R
+bind-key -T copy-mode-vi C-\ select-pane -l

--- a/dotfiles/.tmux.conf
+++ b/dotfiles/.tmux.conf
@@ -11,6 +11,7 @@ bind -n M-Left select-pane -L
 bind -n M-Right select-pane -R
 bind -n M-Up select-pane -U
 bind -n M-Down select-pane -D
+bind -n M-\ select-pane -l
 
 # vi like copying
 set-window-option -g mode-keys vi

--- a/dotfiles/.tmux.conf
+++ b/dotfiles/.tmux.conf
@@ -22,13 +22,13 @@ set -s escape-time 0
 # See: https://github.com/christoomey/vim-tmux-navigator
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
     | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-bind-key -n C-h if-shell "$is_vim" "send-keys C-h"  "select-pane -L"
-bind-key -n C-j if-shell "$is_vim" "send-keys C-j"  "select-pane -D"
-bind-key -n C-k if-shell "$is_vim" "send-keys C-k"  "select-pane -U"
-bind-key -n C-l if-shell "$is_vim" "send-keys C-l"  "select-pane -R"
-bind-key -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
-bind-key -T copy-mode-vi C-h select-pane -L
-bind-key -T copy-mode-vi C-j select-pane -D
-bind-key -T copy-mode-vi C-k select-pane -U
-bind-key -T copy-mode-vi C-l select-pane -R
-bind-key -T copy-mode-vi C-\ select-pane -l
+bind-key -n M-Left if-shell "$is_vim" "send-keys M-h"  "select-pane -L"
+bind-key -n M-Down if-shell "$is_vim" "send-keys M-j"  "select-pane -D"
+bind-key -n M-Up if-shell "$is_vim" "send-keys M-k"  "select-pane -U"
+bind-key -n M-Right if-shell "$is_vim" "send-keys M-l"  "select-pane -R"
+bind-key -n M-\ if-shell "$is_vim" "send-keys M-\\" "select-pane -l"
+bind-key -T copy-mode-vi M-Left select-pane -L
+bind-key -T copy-mode-vi M-Down select-pane -D
+bind-key -T copy-mode-vi M-Up select-pane -U
+bind-key -T copy-mode-vi M-Right select-pane -R
+bind-key -T copy-mode-vi M-\ select-pane -l

--- a/dotfiles/.vimrc
+++ b/dotfiles/.vimrc
@@ -15,7 +15,7 @@ call vundle#begin()
 Plugin 'VundleVim/Vundle.vim'
 
 " custom plugins
-" None yet
+Plugin 'christoomey/vim-tmux-navigator'
 
 " All of your Plugins must be added before the following line
 call vundle#end()            " required

--- a/dotfiles/.vimrc
+++ b/dotfiles/.vimrc
@@ -121,19 +121,42 @@ nnoremap <C-n> :call NumberToggle()<CR>
 nnoremap <Up> gk
 nnoremap <Down> gj
 
-" navigate splits with ctrl + hjkl
-nmap <silent> <C-k> :wincmd k<CR>
-nmap <silent> <C-j> :wincmd j<CR>
-nmap <silent> <C-h> :wincmd h<CR>
-nmap <silent> <C-l> :wincmd l<CR>
+" integrate with tmux navigation
+let g:tmux_navigator_no_mappings = 1
 
+execute "set <M-k>=\ek"
+execute "set <M-j>=\ej"
+execute "set <M-h>=\eh"
+execute "set <M-l>=\el"
+nnoremap <silent> <M-k> :TmuxNavigateUp<cr>
+nnoremap <silent> <M-j> :TmuxNavigateDown<cr>
+nnoremap <silent> <M-h> :TmuxNavigateRight<cr>
+nnoremap <silent> <M-l> :TmuxNavigateLeft<cr>
+" nnoremap <silent> {Previous-Mapping} :TmuxNavigatePrevious<cr>
+
+" " navigate splits with ctrl + hjkl
+" nmap <silent> <C-k> :wincmd k<CR>
+" nmap <silent> <C-j> :wincmd j<CR>
+" nmap <silent> <C-h> :wincmd h<CR>
+" nmap <silent> <C-l> :wincmd l<CR>
+"
 " navigate vim splits with ctrl + arrow keys
-nmap <silent> <ESC>[A :wincmd k<CR>
-nmap <silent> <ESC>[B :wincmd j<CR>
-nmap <silent> <ESC>[D :wincmd h<CR>
-nmap <silent> <ESC>[C :wincmd l<CR>
+" nmap <silent> <ESC>[A :wincmd k<CR>
+" nmap <silent> <ESC>[B :wincmd j<CR>
+" nmap <silent> <ESC>[D :wincmd h<CR>
+" nmap <silent> <ESC>[C :wincmd l<CR>
+"
+" " alt + hjkl navigation
+" execute "set <M-k>=\ek"
+" execute "set <M-j>=\ej"
+" execute "set <M-h>=\eh"
+" execute "set <M-l>=\el"
+" nmap <silent> <M-k> :wincmd k<CR>
+" nmap <silent> <M-j> :wincmd j<CR>
+" nmap <silent> <M-h> :wincmd h<CR>
+" nmap <silent> <M-l> :wincmd l<CR>
 
-" map SpaceToComment to ctrl+m
+" map SpaceToComment to alt+m
 execute "set <M-m>=\em"
 nnoremap <M-m> :call SpaceToComment(' ')<CR>
 

--- a/dotfiles/.vimrc
+++ b/dotfiles/.vimrc
@@ -127,6 +127,12 @@ nmap <silent> <C-j> :wincmd j<CR>
 nmap <silent> <C-h> :wincmd h<CR>
 nmap <silent> <C-l> :wincmd l<CR>
 
+" navigate vim splits with ctrl + arrow keys
+nmap <silent> <ESC>[A :wincmd k<CR>
+nmap <silent> <ESC>[B :wincmd j<CR>
+nmap <silent> <ESC>[D :wincmd h<CR>
+nmap <silent> <ESC>[C :wincmd l<CR>
+
 " map SpaceToComment to ctrl+m
 execute "set <M-m>=\em"
 nnoremap <M-m> :call SpaceToComment(' ')<CR>

--- a/dotfiles/.vimrc
+++ b/dotfiles/.vimrc
@@ -128,33 +128,12 @@ execute "set <A-k>=\ek"
 execute "set <A-j>=\ej"
 execute "set <A-h>=\eh"
 execute "set <A-l>=\el"
+execute "set <A-\\>=\e\\"
 nnoremap <silent> <A-k> :TmuxNavigateUp<cr>
 nnoremap <silent> <A-j> :TmuxNavigateDown<cr>
 nnoremap <silent> <A-h> :TmuxNavigateRight<cr>
 nnoremap <silent> <A-l> :TmuxNavigateLeft<cr>
-" nnoremap <silent> {Previous-Mapping} :TmuxNavigatePrevious<cr>
-
-" " navigate splits with ctrl + hjkl
-" nmap <silent> <C-k> :wincmd k<CR>
-" nmap <silent> <C-j> :wincmd j<CR>
-" nmap <silent> <C-h> :wincmd h<CR>
-" nmap <silent> <C-l> :wincmd l<CR>
-"
-" navigate vim splits with ctrl + arrow keys
-" nmap <silent> <ESC>[A :wincmd k<CR>
-" nmap <silent> <ESC>[B :wincmd j<CR>
-" nmap <silent> <ESC>[D :wincmd h<CR>
-" nmap <silent> <ESC>[C :wincmd l<CR>
-"
-" " alt + hjkl navigation
-" execute "set <M-k>=\ek"
-" execute "set <M-j>=\ej"
-" execute "set <M-h>=\eh"
-" execute "set <M-l>=\el"
-" nmap <silent> <M-k> :wincmd k<CR>
-" nmap <silent> <M-j> :wincmd j<CR>
-" nmap <silent> <M-h> :wincmd h<CR>
-" nmap <silent> <M-l> :wincmd l<CR>
+nnoremap <silent> <A-\> :TmuxNavigatePrevious<cr>
 
 " map SpaceToComment to alt+m
 execute "set <M-m>=\em"

--- a/dotfiles/.vimrc
+++ b/dotfiles/.vimrc
@@ -124,14 +124,14 @@ nnoremap <Down> gj
 " integrate with tmux navigation
 let g:tmux_navigator_no_mappings = 1
 
-execute "set <M-k>=\ek"
-execute "set <M-j>=\ej"
-execute "set <M-h>=\eh"
-execute "set <M-l>=\el"
-nnoremap <silent> <M-k> :TmuxNavigateUp<cr>
-nnoremap <silent> <M-j> :TmuxNavigateDown<cr>
-nnoremap <silent> <M-h> :TmuxNavigateRight<cr>
-nnoremap <silent> <M-l> :TmuxNavigateLeft<cr>
+execute "set <A-k>=\ek"
+execute "set <A-j>=\ej"
+execute "set <A-h>=\eh"
+execute "set <A-l>=\el"
+nnoremap <silent> <A-k> :TmuxNavigateUp<cr>
+nnoremap <silent> <A-j> :TmuxNavigateDown<cr>
+nnoremap <silent> <A-h> :TmuxNavigateRight<cr>
+nnoremap <silent> <A-l> :TmuxNavigateLeft<cr>
 " nnoremap <silent> {Previous-Mapping} :TmuxNavigatePrevious<cr>
 
 " " navigate splits with ctrl + hjkl

--- a/dotfiles/.vimrc
+++ b/dotfiles/.vimrc
@@ -117,10 +117,15 @@ endfun
 " map NumberToggle
 nnoremap <C-n> :call NumberToggle()<CR>
 
-" move up by visual line
+" move up/down by visual line
 nnoremap <Up> gk
-" move down by visual line
 nnoremap <Down> gj
+
+" navigate splits with ctrl + hjkl
+nmap <silent> <C-k> :wincmd k<CR>
+nmap <silent> <C-j> :wincmd j<CR>
+nmap <silent> <C-h> :wincmd h<CR>
+nmap <silent> <C-l> :wincmd l<CR>
 
 " map SpaceToComment to ctrl+m
 execute "set <M-m>=\em"


### PR DESCRIPTION
Modifies `.tmux.conf` and `.vimrc` to allow alt+arrow key mappings to move between tmux panes, vim splits and between tmux/vim.